### PR TITLE
MySQL Adaptor: Using information_schema to get list of tables

### DIFF
--- a/src/db/mysql-adapter.ts
+++ b/src/db/mysql-adapter.ts
@@ -133,7 +133,7 @@ export class MysqlAdapter implements DbAdapter {
    * Get database-specific query for listing tables
    */
   getListTablesQuery(): string {
-    return "SHOW TABLES";
+    return `SELECT table_name AS name FROM information_schema.tables WHERE table_schema = '${this.database}'`;
   }
 
   /**


### PR DESCRIPTION
Using information_schema  instead of show tables, because show tables returns column name different.