### PR TITLE
Feature/aws iam authentication

### DIFF
--- a/docs/docs/connection-reference.md
+++ b/docs/docs/connection-reference.md
@@ -75,16 +75,27 @@ node dist/src/index.js --postgresql --host dbserver.example.com --database sampl
 | `--mysql` | Specifies MySQL mode | - | Yes |
 | `--host` | MySQL hostname or IP | - | Yes |
 | `--database` | Database name | - | Yes |
-| `--user` | MySQL username | - | No |
-| `--password` | MySQL password | - | No |
+| `--user` | MySQL username | - | No* |
+| `--password` | MySQL password | - | No* |
 | `--port` | MySQL port | 3306 | No |
 | `--ssl` | Use SSL connection (true/false or object) | false | No |
 | `--connection-timeout` | Connection timeout in ms | 30000 | No |
+| `--aws-iam-auth` | Enable AWS IAM authentication | false | No |
+| `--aws-region` | AWS region for RDS IAM auth | - | No** |
 
-### Example
+*Required for standard authentication  
+**Required when using `--aws-iam-auth`
+
+### Standard Authentication Example
 
 ```bash
 node dist/src/index.js --mysql --host localhost --database sample_db --port 3306 --user root --password secret
+```
+
+### AWS IAM Authentication Example
+
+```bash
+node dist/src/index.js --mysql --aws-iam-auth --host rds-endpoint.region.rds.amazonaws.com --database sample_db --user aws-username --aws-region us-east-1
 ```
 
 ## Environment Variables

--- a/docs/docs/connection-reference.md
+++ b/docs/docs/connection-reference.md
@@ -94,6 +94,12 @@ node dist/src/index.js --mysql --host localhost --database sample_db --port 3306
 
 ### AWS IAM Authentication Example
 
+**Prerequisites:** AWS credentials must be configured using the default credential provider chain:
+- `aws configure` (default profile) 
+- `AWS_PROFILE=myprofile` environment variable
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
+- IAM roles (if running on EC2)
+
 ```bash
 node dist/src/index.js --mysql --aws-iam-auth --host rds-endpoint.region.rds.amazonaws.com --database sample_db --user aws-username --aws-region us-east-1
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "@executeautomation/database-server",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@executeautomation/database-server",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
+                "@aws-sdk/rds-signer": "^3.0.0",
                 "@modelcontextprotocol/sdk": "1.9.0",
                 "mssql": "11.0.1",
                 "mysql2": "^3.14.1",
@@ -25,6 +26,654 @@
                 "rimraf": "^5.0.5",
                 "shx": "0.4.0",
                 "typescript": "5.8.3"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.846.0.tgz",
+            "integrity": "sha512-vlzQVq1TOOYHPppmON/+oNhCxprCPPqxlqAuUddf885JcT6Q9r7FeV7S2yHli/1XC6vBa7sAninNvOjzwDbwYw==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/credential-provider-node": "3.846.0",
+                "@aws-sdk/middleware-host-header": "3.840.0",
+                "@aws-sdk/middleware-logger": "3.840.0",
+                "@aws-sdk/middleware-recursion-detection": "3.840.0",
+                "@aws-sdk/middleware-user-agent": "3.846.0",
+                "@aws-sdk/region-config-resolver": "3.840.0",
+                "@aws-sdk/types": "3.840.0",
+                "@aws-sdk/util-endpoints": "3.845.0",
+                "@aws-sdk/util-user-agent-browser": "3.840.0",
+                "@aws-sdk/util-user-agent-node": "3.846.0",
+                "@smithy/config-resolver": "^4.1.4",
+                "@smithy/core": "^3.7.0",
+                "@smithy/fetch-http-handler": "^5.1.0",
+                "@smithy/hash-node": "^4.0.4",
+                "@smithy/invalid-dependency": "^4.0.4",
+                "@smithy/middleware-content-length": "^4.0.4",
+                "@smithy/middleware-endpoint": "^4.1.15",
+                "@smithy/middleware-retry": "^4.1.16",
+                "@smithy/middleware-serde": "^4.0.8",
+                "@smithy/middleware-stack": "^4.0.4",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/node-http-handler": "^4.1.0",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/smithy-client": "^4.4.7",
+                "@smithy/types": "^4.3.1",
+                "@smithy/url-parser": "^4.0.4",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.23",
+                "@smithy/util-defaults-mode-node": "^4.0.23",
+                "@smithy/util-endpoints": "^3.0.6",
+                "@smithy/util-middleware": "^4.0.4",
+                "@smithy/util-retry": "^4.0.6",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.846.0.tgz",
+            "integrity": "sha512-7MgMl3nlwf2ixad5Xe8pFHtcwFchkx37MEvGuB00tn5jyBp3AQQ4dK3iHtj2HjhXcXD0G67zVPvH4/QNOL7/gw==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/middleware-host-header": "3.840.0",
+                "@aws-sdk/middleware-logger": "3.840.0",
+                "@aws-sdk/middleware-recursion-detection": "3.840.0",
+                "@aws-sdk/middleware-user-agent": "3.846.0",
+                "@aws-sdk/region-config-resolver": "3.840.0",
+                "@aws-sdk/types": "3.840.0",
+                "@aws-sdk/util-endpoints": "3.845.0",
+                "@aws-sdk/util-user-agent-browser": "3.840.0",
+                "@aws-sdk/util-user-agent-node": "3.846.0",
+                "@smithy/config-resolver": "^4.1.4",
+                "@smithy/core": "^3.7.0",
+                "@smithy/fetch-http-handler": "^5.1.0",
+                "@smithy/hash-node": "^4.0.4",
+                "@smithy/invalid-dependency": "^4.0.4",
+                "@smithy/middleware-content-length": "^4.0.4",
+                "@smithy/middleware-endpoint": "^4.1.15",
+                "@smithy/middleware-retry": "^4.1.16",
+                "@smithy/middleware-serde": "^4.0.8",
+                "@smithy/middleware-stack": "^4.0.4",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/node-http-handler": "^4.1.0",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/smithy-client": "^4.4.7",
+                "@smithy/types": "^4.3.1",
+                "@smithy/url-parser": "^4.0.4",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.23",
+                "@smithy/util-defaults-mode-node": "^4.0.23",
+                "@smithy/util-endpoints": "^3.0.6",
+                "@smithy/util-middleware": "^4.0.4",
+                "@smithy/util-retry": "^4.0.6",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.846.0.tgz",
+            "integrity": "sha512-7CX0pM906r4WSS68fCTNMTtBCSkTtf3Wggssmx13gD40gcWEZXsU00KzPp1bYheNRyPlAq3rE22xt4wLPXbuxA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.840.0",
+                "@aws-sdk/xml-builder": "3.821.0",
+                "@smithy/core": "^3.7.0",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/signature-v4": "^5.1.2",
+                "@smithy/smithy-client": "^4.4.7",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.4",
+                "@smithy/util-utf8": "^4.0.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.846.0.tgz",
+            "integrity": "sha512-zfcNFUK0QC7czR/n3ATMp3ZWkMrGZzJ1mS/sTezjFg1IupFnogyF+8xKmnmqXiABJd1yE8FduYgw8yx0ZSWiCw==",
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.846.0.tgz",
+            "integrity": "sha512-QuCQZET9enja7AWVISY+mpFrEIeHzvkx/JEEbHYzHhUkxcnC2Kq2c0bB7hDihGD0AZd3Xsm653hk1O97qu69zg==",
+            "dependencies": {
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.846.0.tgz",
+            "integrity": "sha512-Jh1iKUuepdmtreMYozV2ePsPcOF5W9p3U4tWhi3v6nDvz0GsBjzjAROW+BW8XMz9vAD3I9R+8VC3/aq63p5nlw==",
+            "dependencies": {
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/fetch-http-handler": "^5.1.0",
+                "@smithy/node-http-handler": "^4.1.0",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/smithy-client": "^4.4.7",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-stream": "^4.2.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.846.0.tgz",
+            "integrity": "sha512-GUxaBBKsYx1kOlRbcs77l6BVyG9K70zekJX+5hdwTEgJq7AoHl/XYoWiDxPf6zQ7J4euixPJoyRhpNbJjAXdFw==",
+            "dependencies": {
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/credential-provider-env": "3.846.0",
+                "@aws-sdk/credential-provider-http": "3.846.0",
+                "@aws-sdk/credential-provider-process": "3.846.0",
+                "@aws-sdk/credential-provider-sso": "3.846.0",
+                "@aws-sdk/credential-provider-web-identity": "3.846.0",
+                "@aws-sdk/nested-clients": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/credential-provider-imds": "^4.0.6",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/shared-ini-file-loader": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.846.0.tgz",
+            "integrity": "sha512-du2DsXYRfQ8VIt/gXGThhT8KdUEt2j9W91W87Bl9IA5DINt4nSZv+gzh8LqHBYsTSqoUpKb+qIfP1RjZM/8r0A==",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.846.0",
+                "@aws-sdk/credential-provider-http": "3.846.0",
+                "@aws-sdk/credential-provider-ini": "3.846.0",
+                "@aws-sdk/credential-provider-process": "3.846.0",
+                "@aws-sdk/credential-provider-sso": "3.846.0",
+                "@aws-sdk/credential-provider-web-identity": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/credential-provider-imds": "^4.0.6",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/shared-ini-file-loader": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.846.0.tgz",
+            "integrity": "sha512-mEpwDYarJSH+CIXnnHN0QOe0MXI+HuPStD6gsv3z/7Q6ESl8KRWon3weFZCDnqpiJMUVavlDR0PPlAFg2MQoPg==",
+            "dependencies": {
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/shared-ini-file-loader": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.846.0.tgz",
+            "integrity": "sha512-Dxz9dpdjfxUsSfW92SAldu9wy8wgEbskn4BNWBFHslQHTmqurmR0ci4P1SMxJJKd498AUEoIAzZOtjGOC38irQ==",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.846.0",
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/token-providers": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/shared-ini-file-loader": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.846.0.tgz",
+            "integrity": "sha512-j6zOd+kynPQJzmVwSKSUTpsLXAf7vKkr7hCPbQyqC8ZqkIuExsRqu2vRQjX2iH/MKhwZ+qEWMxPMhfDoyv7Gag==",
+            "dependencies": {
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/nested-clients": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.846.0.tgz",
+            "integrity": "sha512-YpTJcV5PO0V+I1nRGAyNF/kCcOIgPgzihlAyOqicmq3vZ8UHZqUCOfzcS6qbEpPFeAB3domzBgsAJNsQXht4SA==",
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.846.0",
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/credential-provider-cognito-identity": "3.846.0",
+                "@aws-sdk/credential-provider-env": "3.846.0",
+                "@aws-sdk/credential-provider-http": "3.846.0",
+                "@aws-sdk/credential-provider-ini": "3.846.0",
+                "@aws-sdk/credential-provider-node": "3.846.0",
+                "@aws-sdk/credential-provider-process": "3.846.0",
+                "@aws-sdk/credential-provider-sso": "3.846.0",
+                "@aws-sdk/credential-provider-web-identity": "3.846.0",
+                "@aws-sdk/nested-clients": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/config-resolver": "^4.1.4",
+                "@smithy/core": "^3.7.0",
+                "@smithy/credential-provider-imds": "^4.0.6",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.840.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.840.0.tgz",
+            "integrity": "sha512-ub+hXJAbAje94+Ya6c6eL7sYujoE8D4Bumu1NUI8TXjUhVVn0HzVWQjpRLshdLsUp1AW7XyeJaxyajRaJQ8+Xg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.840.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.840.0.tgz",
+            "integrity": "sha512-lSV8FvjpdllpGaRspywss4CtXV8M7NNNH+2/j86vMH+YCOZ6fu2T/TyFd/tHwZ92vDfHctWkRbQxg0bagqwovA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.840.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.840.0.tgz",
+            "integrity": "sha512-Gu7lGDyfddyhIkj1Z1JtrY5NHb5+x/CRiB87GjaSrKxkDaydtX2CU977JIABtt69l9wLbcGDIQ+W0uJ5xPof7g==",
+            "dependencies": {
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.846.0.tgz",
+            "integrity": "sha512-85/oUc2jMXqQWo+HHH7WwrdqqArzhMmTmBCpXZwklBHG+ZMzTS5Wug2B0HhGDVWo9aYRMeikSq4lsrpHFVd2MQ==",
+            "dependencies": {
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@aws-sdk/util-endpoints": "3.845.0",
+                "@smithy/core": "^3.7.0",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.846.0.tgz",
+            "integrity": "sha512-LCXPVtNQnkTuE8inPCtpfWN2raE/ndFBKf5OIbuHnC/0XYGOUl5q7VsJz471zJuN9FX3WMfopaFwmNc7cQNMpQ==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/middleware-host-header": "3.840.0",
+                "@aws-sdk/middleware-logger": "3.840.0",
+                "@aws-sdk/middleware-recursion-detection": "3.840.0",
+                "@aws-sdk/middleware-user-agent": "3.846.0",
+                "@aws-sdk/region-config-resolver": "3.840.0",
+                "@aws-sdk/types": "3.840.0",
+                "@aws-sdk/util-endpoints": "3.845.0",
+                "@aws-sdk/util-user-agent-browser": "3.840.0",
+                "@aws-sdk/util-user-agent-node": "3.846.0",
+                "@smithy/config-resolver": "^4.1.4",
+                "@smithy/core": "^3.7.0",
+                "@smithy/fetch-http-handler": "^5.1.0",
+                "@smithy/hash-node": "^4.0.4",
+                "@smithy/invalid-dependency": "^4.0.4",
+                "@smithy/middleware-content-length": "^4.0.4",
+                "@smithy/middleware-endpoint": "^4.1.15",
+                "@smithy/middleware-retry": "^4.1.16",
+                "@smithy/middleware-serde": "^4.0.8",
+                "@smithy/middleware-stack": "^4.0.4",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/node-http-handler": "^4.1.0",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/smithy-client": "^4.4.7",
+                "@smithy/types": "^4.3.1",
+                "@smithy/url-parser": "^4.0.4",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.23",
+                "@smithy/util-defaults-mode-node": "^4.0.23",
+                "@smithy/util-endpoints": "^3.0.6",
+                "@smithy/util-middleware": "^4.0.4",
+                "@smithy/util-retry": "^4.0.6",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/rds-signer": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/rds-signer/-/rds-signer-3.846.0.tgz",
+            "integrity": "sha512-/8pIiLYxv1U83KhpBZcVjmMUw1Bjw92lAyqktizpyXlK0CczWMMV6bvVLaZ2uAnMH4CbV0uzqRWzbOjigVgpgg==",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/credential-providers": "3.846.0",
+                "@aws-sdk/util-format-url": "3.840.0",
+                "@smithy/config-resolver": "^4.1.4",
+                "@smithy/hash-node": "^4.0.4",
+                "@smithy/invalid-dependency": "^4.0.4",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/signature-v4": "^5.1.2",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.840.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.840.0.tgz",
+            "integrity": "sha512-Qjnxd/yDv9KpIMWr90ZDPtRj0v75AqGC92Lm9+oHXZ8p1MjG5JE2CW0HL8JRgK9iKzgKBL7pPQRXI8FkvEVfrA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.846.0.tgz",
+            "integrity": "sha512-sGNk3xclK7xx+rIJZDJC4FNFqaSSqN0nSr+AdVdQ+/iKQKaUA6hixRbXaQ7I7M5mhqS6fMW1AsqVRywQq2BSMw==",
+            "dependencies": {
+                "@aws-sdk/core": "3.846.0",
+                "@aws-sdk/nested-clients": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/shared-ini-file-loader": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.840.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.840.0.tgz",
+            "integrity": "sha512-xliuHaUFZxEx1NSXeLLZ9Dyu6+EJVQKEoD+yM+zqUo3YDZ7medKJWY6fIOKiPX/N7XbLdBYwajb15Q7IL8KkeA==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.845.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.845.0.tgz",
+            "integrity": "sha512-MBmOf0Pb4q6xs9V7jXT1+qciW2965yvaoZUlUUnxUEoX6zxWROeIu/gttASc4vSjOHr/+64hmFkxjeBUF37FJA==",
+            "dependencies": {
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/types": "^4.3.1",
+                "@smithy/url-parser": "^4.0.4",
+                "@smithy/util-endpoints": "^3.0.6",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-format-url": {
+            "version": "3.840.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.840.0.tgz",
+            "integrity": "sha512-VB1PWyI1TQPiPvg4w7tgUGGQER1xxXPNUqfh3baxUSFi1Oh8wHrDnFywkxLm3NMmgDmnLnSZ5Q326qAoyqKLSg==",
+            "dependencies": {
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/querystring-builder": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.804.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
+            "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.840.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.840.0.tgz",
+            "integrity": "sha512-JdyZM3EhhL4PqwFpttZu1afDpPJCCc3eyZOLi+srpX11LsGj6sThf47TYQN75HT1CarZ7cCdQHGzP2uy3/xHfQ==",
+            "dependencies": {
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/types": "^4.3.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.846.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.846.0.tgz",
+            "integrity": "sha512-MXYXCplw76xe8A9ejVaIru6Carum/2LQbVtNHsIa4h0TlafLdfulywsoMWL1F53Y9XxQSeOKyyqDKLNOgRVimw==",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.846.0",
+                "@aws-sdk/types": "3.840.0",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.821.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
+            "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@azure/abort-controller": {
@@ -462,6 +1111,629 @@
                 "node": ">=14"
             }
         },
+        "node_modules/@smithy/abort-controller": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
+            "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
+            "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/core": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.7.0.tgz",
+            "integrity": "sha512-7ov8hu/4j0uPZv8b27oeOFtIBtlFmM3ibrPv/Omx1uUdoXvcpJ00U+H/OWWC/keAguLlcqwtyL2/jTlSnApgNQ==",
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.8",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.4",
+                "@smithy/util-stream": "^4.2.3",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
+            "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "@smithy/url-parser": "^4.0.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.0.tgz",
+            "integrity": "sha512-mADw7MS0bYe2OGKkHYMaqarOXuDwRbO6ArD91XhHcl2ynjGCFF+hvqf0LyQcYxkA1zaWjefSkU7Ne9mqgApSgQ==",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/querystring-builder": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
+            "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
+            "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
+            "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.15.tgz",
+            "integrity": "sha512-L2M0oz+r6Wv0KZ90MgClXmWkV7G72519Hd5/+K5i3gQMu4WNQykh7ERr58WT3q60dd9NqHSMc3/bAK0FsFg3Fw==",
+            "dependencies": {
+                "@smithy/core": "^3.7.0",
+                "@smithy/middleware-serde": "^4.0.8",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/shared-ini-file-loader": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "@smithy/url-parser": "^4.0.4",
+                "@smithy/util-middleware": "^4.0.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "4.1.16",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.16.tgz",
+            "integrity": "sha512-PpPhMpC6U1fLW0evKnC8gJtmobBYn0oi4RrIKGhN1a86t6XgVEK+Vb9C8dh5PPXb3YDr8lE6aYKh1hd3OikmWw==",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/service-error-classification": "^4.0.6",
+                "@smithy/smithy-client": "^4.4.7",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-middleware": "^4.0.4",
+                "@smithy/util-retry": "^4.0.6",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
+            "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
+            "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
+            "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/shared-ini-file-loader": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.0.tgz",
+            "integrity": "sha512-vqfSiHz2v8b3TTTrdXi03vNz1KLYYS3bhHCDv36FYDqxT7jvTll1mMnCrkD+gOvgwybuunh/2VmvOMqwBegxEg==",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/querystring-builder": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
+            "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
+            "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
+            "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
+            "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz",
+            "integrity": "sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
+            "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
+            "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.4",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "4.4.7",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.7.tgz",
+            "integrity": "sha512-x+MxBNOcG7rY9i5QsbdgvvRJngKKvUJrbU5R5bT66PTH3e6htSupJ4Q+kJ3E7t6q854jyl57acjpPi6qG1OY5g==",
+            "dependencies": {
+                "@smithy/core": "^3.7.0",
+                "@smithy/middleware-endpoint": "^4.1.15",
+                "@smithy/middleware-stack": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.2",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-stream": "^4.2.3",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
+            "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
+            "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.4",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.23",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.23.tgz",
+            "integrity": "sha512-NqRi6VvEIwpJ+KSdqI85+HH46H7uVoNqVTs2QO7p1YKnS7k8VZnunJj8R5KdmmVnTojkaL1OMPyZC8uR5F7fSg==",
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/smithy-client": "^4.4.7",
+                "@smithy/types": "^4.3.1",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.23",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.23.tgz",
+            "integrity": "sha512-NE9NtEVigFa+HHJ5bBeQT7KF3KiltW880CLN9TnWWL55akeou3ziRAHO22QSUPgPZ/nqMfPXi/LGMQ6xQvXPNQ==",
+            "dependencies": {
+                "@smithy/config-resolver": "^4.1.4",
+                "@smithy/credential-provider-imds": "^4.0.6",
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/property-provider": "^4.0.4",
+                "@smithy/smithy-client": "^4.4.7",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
+            "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.1.3",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
+            "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
+            "dependencies": {
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.6.tgz",
+            "integrity": "sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==",
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.6",
+                "@smithy/types": "^4.3.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.3.tgz",
+            "integrity": "sha512-cQn412DWHHFNKrQfbHY8vSFI3nTROY1aIKji9N0tpp8gUABRilr7wdf8fqBbSlXresobM+tQFNk6I+0LXK/YZg==",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.1.0",
+                "@smithy/node-http-handler": "^4.1.0",
+                "@smithy/types": "^4.3.1",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/@tediousjs/connection-string": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/@tediousjs/connection-string/-/connection-string-0.5.0.tgz",
@@ -709,6 +1981,11 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/bowser": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+            "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
         },
         "node_modules/brace-expansion": {
             "version": "2.0.1",
@@ -1478,6 +2755,23 @@
             },
             "engines": {
                 "node": ">=8.6.0"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
             }
         },
         "node_modules/fastq": {
@@ -3949,6 +5243,17 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/strnum": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+            "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ]
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "clean": "rimraf dist"
     },
     "dependencies": {
+        "@aws-sdk/rds-signer": "^3.0.0",
         "@modelcontextprotocol/sdk": "1.9.0",
         "mssql": "11.0.1",
         "mysql2": "^3.14.1",

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,14 @@ Optional parameters:
 
 For Amazon RDS MySQL instances with IAM database authentication:
 
+**Prerequisites:**
+- AWS credentials must be configured (the RDS Signer uses the default credential provider chain)
+- Configure using one of these methods:
+  - `aws configure` (uses default profile)
+  - `AWS_PROFILE=myprofile` environment variable
+  - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables
+  - IAM roles (if running on EC2)
+
 ```
 node dist/src/index.js --mysql --aws-iam-auth --host <rds-endpoint> --database <database-name> --user <aws-username> --aws-region <region>
 ```

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,8 @@ Optional parameters:
 
 ### MySQL Database
 
+#### Standard Authentication
+
 To use with a MySQL database:
 
 ```
@@ -110,6 +112,23 @@ Optional parameters:
 - `--password`: Password for MySQL authentication
 - `--ssl`: Enable SSL connection (true/false or object)
 - `--connection-timeout`: Connection timeout in milliseconds (default: 30000)
+
+#### AWS IAM Authentication
+
+For Amazon RDS MySQL instances with IAM database authentication:
+
+```
+node dist/src/index.js --mysql --aws-iam-auth --host <rds-endpoint> --database <database-name> --user <aws-username> --aws-region <region>
+```
+
+Required parameters:
+- `--host`: RDS endpoint hostname
+- `--database`: Name of the database
+- `--aws-iam-auth`: Enable AWS IAM authentication
+- `--user`: AWS IAM username (also the database user)
+- `--aws-region`: AWS region where RDS instance is located
+
+Note: SSL is automatically enabled for AWS IAM authentication
 
 ## Configuring Claude Desktop
 
@@ -164,6 +183,19 @@ If you installed the package globally, configure Claude Desktop with:
         "--user", "your-username",
         "--password", "your-password"
       ]
+    },
+    "mysql-aws": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@executeautomation/database-server",
+        "--mysql",
+        "--aws-iam-auth",
+        "--host", "your-rds-endpoint.region.rds.amazonaws.com",
+        "--database", "your-database-name",
+        "--user", "your-aws-username",
+        "--aws-region", "us-east-1"
+      ]
     }
   }
 }
@@ -215,6 +247,18 @@ For local development, configure Claude Desktop to use your locally built versio
         "--port", "3306",
         "--user", "your-username",
         "--password", "your-password"
+      ]
+    },
+    "mysql-aws": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/mcp-database-server/dist/src/index.js",
+        "--mysql",
+        "--aws-iam-auth",
+        "--host", "your-rds-endpoint.region.rds.amazonaws.com",
+        "--database", "your-database-name",
+        "--user", "your-aws-username",
+        "--aws-region", "us-east-1"
       ]
     }
   }

--- a/src/db/mysql-adapter.ts
+++ b/src/db/mysql-adapter.ts
@@ -74,7 +74,7 @@ export class MysqlAdapter implements DbAdapter {
     }
     
     try {
-      console.error(`[INFO] Generating AWS auth token for region: ${this.awsRegion}, host: ${this.host}, user: ${this.config.user}`);
+      console.info(`[INFO] Generating AWS auth token for region: ${this.awsRegion}, host: ${this.host}, user: ${this.config.user}`);
       
       const signer = new Signer({
         region: this.awsRegion,
@@ -84,7 +84,7 @@ export class MysqlAdapter implements DbAdapter {
       });
       
       const token = await signer.getAuthToken();
-      console.error(`[INFO] AWS auth token generated successfully`);
+      console.info(`[INFO] AWS auth token generated successfully`);
       return token;
     } catch (err) {
       console.error(`[ERROR] Failed to generate AWS auth token: ${(err as Error).message}`);
@@ -97,11 +97,11 @@ export class MysqlAdapter implements DbAdapter {
    */
   async init(): Promise<void> {
     try {
-      console.error(`[INFO] Connecting to MySQL: ${this.host}, Database: ${this.database}`);
+      console.info(`[INFO] Connecting to MySQL: ${this.host}, Database: ${this.database}`);
       
       // Handle AWS IAM authentication
       if (this.awsIamAuth) {
-        console.error(`[INFO] Using AWS IAM authentication for user: ${this.config.user}`);
+        console.info(`[INFO] Using AWS IAM authentication for user: ${this.config.user}`);
         
         try {
           const authToken = await this.generateAwsAuthToken();
@@ -121,7 +121,7 @@ export class MysqlAdapter implements DbAdapter {
         this.connection = await mysql.createConnection(this.config);
       }
       
-      console.error(`[INFO] MySQL connection established successfully`);
+      console.info(`[INFO] MySQL connection established successfully`);
     } catch (err) {
       console.error(`[ERROR] MySQL connection error: ${(err as Error).message}`);
       if (this.awsIamAuth) {


### PR DESCRIPTION
## Add AWS IAM authentication support for MySQL

This PR adds AWS IAM database authentication for Amazon RDS MySQL instances, enabling secure connections without hardcoded passwords.

### Changes:
- **New CLI options**: `--aws-iam-auth` and `--aws-region`
- **AWS SDK integration**: Uses `@aws-sdk/rds-signer` for automatic token generation
- **SSL auto-configuration**: Automatically enables SSL for AWS IAM connections
- **Error handling**: Clear error messages for AWS credential/permission issues
- **Documentation**: Updated README and connection reference with prerequisites

### Usage:
```bash
node dist/src/index.js --mysql --aws-iam-auth \
  --host your-rds-endpoint.region.rds.amazonaws.com \
  --database your-database \
  --user your-aws-username \
  --aws-region us-east-1
```

### Prerequisites:
AWS credentials must be configured via:
- `aws configure` (default profile)
- Environment variables (`AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, etc.)
- IAM roles (for EC2)

This enables secure AWS RDS connections using IAM authentication while maintaining full compatibility with existing MySQL authentication methods.