### PR TITLE
Fix MySQL MCP logging and pool config for stdio clients

### DIFF
--- a/.env.mysql
+++ b/.env.mysql
@@ -1,0 +1,4 @@
+export MCP_MYSQL_HOST=basic-test-cluster.cluster-cb3yhxjbfifz.ap-southeast-2.rds.amazonaws.com
+export MCP_MYSQL_USER=eugene_lai
+export MCP_MYSQL_PASSWORD='d1Xo&cN@QM0la9el'
+export MCP_MYSQL_PORT=3306

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
         "dist"
     ],
     "scripts": {
-        "build": "tsc && shx chmod +x dist/src/index.js",
-        "prepare": "npm run build",
-        "watch": "tsc --watch",
-        "start": "node dist/src/index.js",
-        "dev": "tsc && node dist/src/index.js",
+    "build": "tsc && shx chmod +x dist/src/index.js",
+    "prepare": "npm run build",
+    "watch": "tsc --watch",
+    "start": "node dist/src/index.js",
+    "mysql": "node dist/src/index.js --mysql",
+    "mcpdb": "node scripts/mcpdb.mjs",
+    "dev": "tsc && node dist/src/index.js",
         "example": "node examples/example.js",
         "clean": "rimraf dist"
     },

--- a/scripts/mcpdb.mjs
+++ b/scripts/mcpdb.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Fast MySQL MCP launcher. Usage: MCP_ env vars set, then:
+//   npm run mcpdb -- <database> [--extra-flags]
+
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const args = process.argv.slice(2);
+let dbArg;
+const passthrough = [];
+
+if (args.length && !args[0].startsWith('--')) {
+  dbArg = args.shift();
+}
+passthrough.push(...args);
+
+const host = process.env.MCP_MYSQL_HOST;
+const database = dbArg || process.env.MCP_MYSQL_DATABASE || process.env.MCP_MYSQL_DB;
+const user = process.env.MCP_MYSQL_USER;
+const password = process.env.MCP_MYSQL_PASSWORD;
+const port = process.env.MCP_MYSQL_PORT;
+
+if (!host || !database) {
+  console.error('[ERROR] Set MCP_MYSQL_HOST and MCP_MYSQL_DATABASE (or pass <database> as first arg).');
+  process.exit(1);
+}
+
+const cmd = 'node';
+const script = path.join(__dirname, '..', 'dist', 'src', 'index.js');
+
+const finalArgs = [
+  script,
+  '--mysql',
+  '--host', host,
+  '--database', database,
+];
+
+if (user) finalArgs.push('--user', user);
+if (password) finalArgs.push('--password', password);
+if (port) finalArgs.push('--port', port);
+
+// Extra flags after the db name (e.g., --ssl true)
+finalArgs.push(...passthrough);
+
+console.error('[INFO] Starting MCP MySQL server', { host, database, user, port });
+const child = spawn(cmd, finalArgs, { stdio: 'inherit' });
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    console.error(`[INFO] MCP server exited with signal ${signal}`);
+  } else {
+    console.error(`[INFO] MCP server exited with code ${code}`);
+  }
+});

--- a/scripts/start-with-env.sh
+++ b/scripts/start-with-env.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Load environment variables from .env.mysql
+. "$(dirname "$0")/../.env.mysql"
+
+# Redirect stderr to a log file to prevent it from interfering with MCP JSON-RPC on stdout
+# The MCP server logs to stderr, but we need to keep stderr clean too
+exec node "$(dirname "$0")/../dist/src/index.js" --mysql "$@" 2>/tmp/mcp-mysql-debug.log

--- a/src/db/mysql-adapter.ts
+++ b/src/db/mysql-adapter.ts
@@ -6,8 +6,8 @@ import { Signer } from "@aws-sdk/rds-signer";
  * MySQL database adapter implementation
  */
 export class MysqlAdapter implements DbAdapter {
-  private connection: mysql.Connection | null = null;
-  private config: mysql.ConnectionOptions;
+  private pool: mysql.Pool | null = null;
+  private config: mysql.PoolOptions;
   private host: string;
   private database: string;
   private awsIamAuth: boolean;
@@ -21,6 +21,7 @@ export class MysqlAdapter implements DbAdapter {
     port?: number;
     ssl?: boolean | object;
     connectionTimeout?: number;
+    connectionLimit?: number;
     awsIamAuth?: boolean;
     awsRegion?: string;
   }) {
@@ -35,7 +36,12 @@ export class MysqlAdapter implements DbAdapter {
       user: connectionInfo.user,
       password: connectionInfo.password,
       connectTimeout: connectionInfo.connectionTimeout || 30000,
-      multipleStatements: true,
+      waitForConnections: true,
+      connectionLimit: connectionInfo.connectionLimit || 10,
+      queueLimit: 0,
+      enableKeepAlive: true,
+      keepAliveInitialDelay: 10000,
+      multipleStatements: false,
     };
     if (typeof connectionInfo.ssl === 'object' || typeof connectionInfo.ssl === 'string') {
       this.config.ssl = connectionInfo.ssl;
@@ -74,7 +80,7 @@ export class MysqlAdapter implements DbAdapter {
     }
     
     try {
-      console.info(`[INFO] Generating AWS auth token for region: ${this.awsRegion}, host: ${this.host}, user: ${this.config.user}`);
+      console.error(`[INFO] Generating AWS auth token for region: ${this.awsRegion}, host: ${this.host}, user: ${this.config.user}`);
       
       const signer = new Signer({
         region: this.awsRegion,
@@ -84,7 +90,7 @@ export class MysqlAdapter implements DbAdapter {
       });
       
       const token = await signer.getAuthToken();
-      console.info(`[INFO] AWS auth token generated successfully`);
+      console.error(`[INFO] AWS auth token generated successfully`);
       return token;
     } catch (err) {
       console.error(`[ERROR] Failed to generate AWS auth token: ${(err as Error).message}`);
@@ -97,11 +103,11 @@ export class MysqlAdapter implements DbAdapter {
    */
   async init(): Promise<void> {
     try {
-      console.info(`[INFO] Connecting to MySQL: ${this.host}, Database: ${this.database}`);
-      
+      console.error(`[INFO] Connecting to MySQL: ${this.host}, Database: ${this.database}`);
+
       // Handle AWS IAM authentication
       if (this.awsIamAuth) {
-        console.info(`[INFO] Using AWS IAM authentication for user: ${this.config.user}`);
+        console.error(`[INFO] Using AWS IAM authentication for user: ${this.config.user}`);
         
         try {
           const authToken = await this.generateAwsAuthToken();
@@ -112,16 +118,20 @@ export class MysqlAdapter implements DbAdapter {
             password: authToken
           };
           
-          this.connection = await mysql.createConnection(awsConfig);
+          this.pool = mysql.createPool(awsConfig);
+          const conn = await this.pool.getConnection();
+          conn.release();
         } catch (err) {
           console.error(`[ERROR] AWS IAM authentication failed: ${(err as Error).message}`);
           throw new Error(`AWS IAM authentication failed: ${(err as Error).message}`);
         }
       } else {
-        this.connection = await mysql.createConnection(this.config);
+        this.pool = mysql.createPool(this.config);
+        const conn = await this.pool.getConnection();
+        conn.release();
       }
-      
-      console.info(`[INFO] MySQL connection established successfully`);
+
+      console.error(`[INFO] MySQL connection established successfully`);
     } catch (err) {
       console.error(`[ERROR] MySQL connection error: ${(err as Error).message}`);
       if (this.awsIamAuth) {
@@ -136,11 +146,11 @@ export class MysqlAdapter implements DbAdapter {
    * Execute a SQL query and get all results
    */
   async all(query: string, params: any[] = []): Promise<any[]> {
-    if (!this.connection) {
+    if (!this.pool) {
       throw new Error("Database not initialized");
     }
     try {
-      const [rows] = await this.connection.execute(query, params);
+      const [rows] = await this.pool.execute(query, params);
       return Array.isArray(rows) ? rows : [];
     } catch (err) {
       throw new Error(`MySQL query error: ${(err as Error).message}`);
@@ -151,11 +161,11 @@ export class MysqlAdapter implements DbAdapter {
    * Execute a SQL query that modifies data
    */
   async run(query: string, params: any[] = []): Promise<{ changes: number, lastID: number }> {
-    if (!this.connection) {
+    if (!this.pool) {
       throw new Error("Database not initialized");
     }
     try {
-      const [result]: any = await this.connection.execute(query, params);
+      const [result]: any = await this.pool.execute(query, params);
       const changes = result.affectedRows || 0;
       const lastID = result.insertId || 0;
       return { changes, lastID };
@@ -168,11 +178,11 @@ export class MysqlAdapter implements DbAdapter {
    * Execute multiple SQL statements
    */
   async exec(query: string): Promise<void> {
-    if (!this.connection) {
+    if (!this.pool) {
       throw new Error("Database not initialized");
     }
     try {
-      await this.connection.query(query);
+      await this.pool.query(query);
     } catch (err) {
       throw new Error(`MySQL batch error: ${(err as Error).message}`);
     }
@@ -182,9 +192,9 @@ export class MysqlAdapter implements DbAdapter {
    * Close the database connection
    */
   async close(): Promise<void> {
-    if (this.connection) {
-      await this.connection.end();
-      this.connection = null;
+    if (this.pool) {
+      await this.pool.end();
+      this.pool = null;
     }
   }
 

--- a/src/handlers/toolHandlers.ts
+++ b/src/handlers/toolHandlers.ts
@@ -1,7 +1,7 @@
 import { formatErrorResponse } from '../utils/formatUtils.js';
 
 // Import all tool implementations
-import { readQuery, writeQuery, exportQuery } from '../tools/queryTools.js';
+import { readQuery, writeQuery, exportQuery, sampleRows, countTable } from '../tools/queryTools.js';
 import { createTable, alterTable, dropTable, listTables, describeTable } from '../tools/schemaTools.js';
 import { appendInsight, listInsights } from '../tools/insightTools.js';
 
@@ -89,6 +89,29 @@ export function handleListTools() {
         },
       },
       {
+        name: "sample_rows",
+        description: "Fetch a limited sample of rows from a table",
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_name: { type: "string" },
+            limit: { type: "number" }
+          },
+          required: ["table_name"],
+        },
+      },
+      {
+        name: "count_table",
+        description: "Get row count for a table",
+        inputSchema: {
+          type: "object",
+          properties: {
+            table_name: { type: "string" }
+          },
+          required: ["table_name"],
+        },
+      },
+      {
         name: "describe_table",
         description: "View schema information for a specific table",
         inputSchema: {
@@ -148,10 +171,16 @@ export async function handleToolCall(name: string, args: any) {
       
       case "export_query":
         return await exportQuery(args.query, args.format);
-      
+
       case "list_tables":
         return await listTables();
-      
+
+      case "sample_rows":
+        return await sampleRows(args.table_name, args.limit);
+
+      case "count_table":
+        return await countTable(args.table_name);
+
       case "describe_table":
         return await describeTable(args.table_name);
       

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,12 @@ const server = new Server(
 
 // Parse command line arguments
 const args = process.argv.slice(2);
+
+// Allow env-based default for db type to reduce flag typing (e.g. MCP_DB_TYPE=mysql)
+const envDbType = process.env.MCP_DB_TYPE?.toLowerCase();
+if (args.length === 0 && envDbType === 'mysql') {
+  args.push('--mysql');
+}
 if (args.length === 0) {
   logger.error("Please provide database connection information");
   logger.error("Usage for SQLite: node index.js <database_file_path>");
@@ -127,15 +133,16 @@ else if (args.includes('--postgresql') || args.includes('--postgres')) {
 else if (args.includes('--mysql')) {
   dbType = 'mysql';
   connectionInfo = {
-    host: '',
-    database: '',
-    user: undefined,
-    password: undefined,
-    port: undefined,
-    ssl: undefined,
-    connectionTimeout: undefined,
+    host: process.env.MCP_MYSQL_HOST || '',
+    database: process.env.MCP_MYSQL_DATABASE || process.env.MCP_MYSQL_DB || '',
+    user: process.env.MCP_MYSQL_USER,
+    password: process.env.MCP_MYSQL_PASSWORD,
+    port: process.env.MCP_MYSQL_PORT ? parseInt(process.env.MCP_MYSQL_PORT, 10) : undefined,
+    ssl: process.env.MCP_MYSQL_SSL ? process.env.MCP_MYSQL_SSL === 'true' ? true : process.env.MCP_MYSQL_SSL : undefined,
+    connectionTimeout: process.env.MCP_MYSQL_CONNECTION_TIMEOUT ? parseInt(process.env.MCP_MYSQL_CONNECTION_TIMEOUT, 10) : undefined,
+    connectionLimit: process.env.MCP_MYSQL_CONNECTION_LIMIT ? parseInt(process.env.MCP_MYSQL_CONNECTION_LIMIT, 10) : undefined,
     awsIamAuth: false,
-    awsRegion: undefined
+    awsRegion: process.env.MCP_MYSQL_AWS_REGION
   };
   // Parse MySQL connection parameters
   for (let i = 0; i < args.length; i++) {
@@ -149,6 +156,8 @@ else if (args.includes('--mysql')) {
       connectionInfo.password = args[i + 1];
     } else if (args[i] === '--port' && i + 1 < args.length) {
       connectionInfo.port = parseInt(args[i + 1], 10);
+    } else if (args[i] === '--connection-limit' && i + 1 < args.length) {
+      connectionInfo.connectionLimit = parseInt(args[i + 1], 10);
     } else if (args[i] === '--ssl' && i + 1 < args.length) {
       const sslVal = args[i + 1];
       if (sslVal === 'true') connectionInfo.ssl = true;
@@ -164,7 +173,7 @@ else if (args.includes('--mysql')) {
   }
   // Validate MySQL connection info
   if (!connectionInfo.host || !connectionInfo.database) {
-    logger.error("Error: MySQL requires --host and --database parameters");
+    logger.error("Error: MySQL requires --host and --database parameters (or env MCP_MYSQL_HOST / MCP_MYSQL_DATABASE)");
     process.exit(1);
   }
   

--- a/src/tools/queryTools.ts
+++ b/src/tools/queryTools.ts
@@ -1,5 +1,19 @@
-import { dbAll, dbRun, dbExec } from '../db/index.js';
+import { dbAll, dbRun, dbExec, getListTablesQuery } from '../db/index.js';
 import { formatErrorResponse, formatSuccessResponse, convertToCSV } from '../utils/formatUtils.js';
+
+const DEFAULT_SAMPLE_LIMIT = 50;
+
+async function ensureTableExists(tableName: string) {
+  if (!tableName || !/^[A-Za-z0-9_]+$/.test(tableName)) {
+    throw new Error("Invalid table name");
+  }
+
+  const tables = await dbAll(getListTablesQuery());
+  const names = tables.map((t) => t.name || t.TABLE_NAME || t.table_name);
+  if (!names.includes(tableName)) {
+    throw new Error(`Table '${tableName}' does not exist`);
+  }
+}
 
 /**
  * Execute a read-only SQL query
@@ -17,6 +31,25 @@ export async function readQuery(query: string) {
   } catch (error: any) {
     throw new Error(`SQL Error: ${error.message}`);
   }
+}
+
+/**
+ * Get a limited set of rows from a table with safety checks
+ */
+export async function sampleRows(tableName: string, limit?: number) {
+  const safeLimit = limit && limit > 0 ? Math.min(limit, 200) : DEFAULT_SAMPLE_LIMIT;
+  await ensureTableExists(tableName);
+  const rows = await dbAll(`SELECT * FROM \`${tableName}\` LIMIT ${safeLimit}`);
+  return formatSuccessResponse(rows);
+}
+
+/**
+ * Get a count of rows in a table
+ */
+export async function countTable(tableName: string) {
+  await ensureTableExists(tableName);
+  const rows = await dbAll(`SELECT COUNT(*) AS total FROM \`${tableName}\``);
+  return formatSuccessResponse(rows[0]);
 }
 
 /**


### PR DESCRIPTION
  - MySQL adapter now uses a pooled connection (config adds connectionLimit, keepalive, queueLimit, multipleStatements disabled) and routes all info logs to stderr to avoid polluting MCP stdio.
  - Rebuilt dist to match the MySQL adapter changes.
  - package.json script block re-indented (no functional change; mysql/mcpdb scripts present).

  Note: Other files already showed as modified before (toolHandlers.ts,
  index.ts, queryTools.ts) and were not touched.