### PR TITLE
Add --readonly CLI flag to prevent all write operations

### DIFF
--- a/src/handlers/toolHandlers.ts
+++ b/src/handlers/toolHandlers.ts
@@ -6,12 +6,24 @@ import { createTable, alterTable, dropTable, listTables, describeTable } from '.
 import { appendInsight, listInsights } from '../tools/insightTools.js';
 
 /**
+ * Tools that perform write operations on the database.
+ * These are hidden and blocked when the server runs in readonly mode.
+ */
+const WRITE_TOOLS: ReadonlySet<string> = new Set([
+  "write_query",
+  "create_table",
+  "alter_table",
+  "drop_table",
+  "append_insight",
+]);
+
+/**
  * Handle listing available tools
+ * @param readonly Whether the server is in readonly mode
  * @returns List of available tools
  */
-export function handleListTools() {
-  return {
-    tools: [
+export function handleListTools(readonly: boolean = false) {
+  const allTools = [
       {
         name: "read_query",
         description: "Execute SELECT queries to read data from the database",
@@ -118,18 +130,30 @@ export function handleListTools() {
           properties: {},
         },
       },
-    ],
-  };
+  ];
+
+  const tools = readonly
+    ? allTools.filter(tool => !WRITE_TOOLS.has(tool.name))
+    : allTools;
+
+  return { tools };
 }
 
 /**
  * Handle tool call requests
  * @param name Name of the tool to call
  * @param args Arguments for the tool
+ * @param readonly Whether the server is in readonly mode
  * @returns Tool execution result
  */
-export async function handleToolCall(name: string, args: any) {
+export async function handleToolCall(name: string, args: any, readonly: boolean = false) {
   try {
+    if (readonly && WRITE_TOOLS.has(name)) {
+      return formatErrorResponse(
+        `Tool "${name}" is disabled in readonly mode. The server was started with --readonly, which prevents all write operations.`
+      );
+    }
+
     switch (name) {
       case "read_query":
         return await readQuery(args.query);

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,8 @@ const server = new Server(
 
 // Parse command line arguments
 const args = process.argv.slice(2);
+const readonlyMode = args.includes('--readonly');
+
 if (args.length === 0) {
   logger.error("Please provide database connection information");
   logger.error("Usage for SQLite: node index.js <database_file_path>");
@@ -47,6 +49,7 @@ if (args.length === 0) {
   logger.error("Usage for PostgreSQL: node index.js --postgresql --host <host> --database <database> [--user <user> --password <password> --port <port>]");
   logger.error("Usage for MySQL: node index.js --mysql --host <host> --database <database> [--user <user> --password <password> --port <port>]");
   logger.error("Usage for MySQL with AWS IAM: node index.js --mysql --aws-iam-auth --host <rds-endpoint> --database <database> --user <aws-username> --aws-region <region>");
+  logger.error("Global options: [--readonly]");
   process.exit(1);
 }
 
@@ -185,7 +188,12 @@ else if (args.includes('--mysql')) {
 } else {
   // SQLite mode (default)
   dbType = 'sqlite';
-  connectionInfo = args[0]; // First argument is the SQLite file path
+  const dbPath = args.find((arg: string) => !arg.startsWith('--'));
+  if (!dbPath) {
+    logger.error("Please provide a database file path for SQLite mode");
+    process.exit(1);
+  }
+  connectionInfo = dbPath;
   logger.info(`Using SQLite database at path: ${connectionInfo}`);
 }
 
@@ -199,11 +207,11 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return handleListTools();
+  return handleListTools(readonlyMode);
 });
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  return await handleToolCall(request.params.name, request.params.arguments);
+  return await handleToolCall(request.params.name, request.params.arguments, readonlyMode);
 });
 
 // Handle shutdown gracefully
@@ -249,7 +257,11 @@ async function runServer() {
     
     const dbInfo = getDatabaseMetadata();
     logger.info(`Connected to ${dbInfo.name} database`);
-    
+
+    if (readonlyMode) {
+      logger.warn('READONLY MODE ENABLED: All write operations are disabled');
+    }
+
     logger.info('Starting MCP server...');
     const transport = new StdioServerTransport();
     await server.connect(transport);


### PR DESCRIPTION
 ## Summary

  - Add `--readonly` CLI flag that acts as a hard safety toggle to prevent all write operations when connecting to databases
  - Hide write tools from AI agent's tool list entirely in readonly mode (defense in depth)
  - Reject write tool calls with a clear error message if called directly despite being hidden
  - Fix SQLite path parsing to handle flags in any position (`--readonly /path/to/db` previously broke because `args[0]` picked up the flag instead of the path)

  ## Motivation

  AI agents using this MCP server can execute arbitrary write operations (INSERT, UPDATE, DELETE, CREATE/ALTER/DROP TABLE). When connecting to production or shared databases, users need a hard guarantee that no writes can occur regardless of what the
  agent attempts.

  ## How it works

  ```bash
  # Append --readonly to any database command
  node dist/src/index.js --readonly /path/to/database.db
  node dist/src/index.js --readonly --postgresql --host localhost --database mydb

  Write tools blocked in readonly mode:

  ┌────────────────┬────────────────────────────┐
  │      Tool      │         Operation          │
  ├────────────────┼────────────────────────────┤
  │ write_query    │ INSERT, UPDATE, DELETE     │
  ├────────────────┼────────────────────────────┤
  │ create_table   │ CREATE TABLE               │
  ├────────────────┼────────────────────────────┤
  │ alter_table    │ ALTER TABLE                │
  ├────────────────┼────────────────────────────┤
  │ drop_table     │ DROP TABLE                 │
  ├────────────────┼────────────────────────────┤
  │ append_insight │ INSERT (business insights) │
  └────────────────┴────────────────────────────┘

  Read-only tools always available:
  read_query, export_query, list_tables, describe_table, list_insights

  Defense in depth:
  1. Write tools are removed from ListTools response — the AI agent never sees them
  2. If a write tool is called directly anyway, it returns isError: true with a clear message